### PR TITLE
Fix cron syntax to once every day

### DIFF
--- a/.github/workflows/profile-summary-cards.yml
+++ b/.github/workflows/profile-summary-cards.yml
@@ -4,7 +4,7 @@ on:
   create:
   push:
   schedule: # execute every 24 hours
-    - cron: "* */24 * * *"
+    - cron: "0 */24 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Description

As you can see here:
![Screenshot 2021-04-24 at 12 30 21](https://user-images.githubusercontent.com/32591853/115955754-d823c680-a4f8-11eb-8a09-0b5c5742ffa1.png)
the current cron syntax states that it runs every minute of the 0 th hour of every day.
Github Actions limits this that it only runs at most every 5 minutes but I still think the syntax of

"0 */24 * * *" would be more correct so that it would every day ONCE at 0:00
you can also use this little site to check the cron syntax https://crontab.guru/
